### PR TITLE
Fix intermittent CI errors on Mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     name: Test with Node.js v${{ matrix.node }} and ${{ matrix.os }}

--- a/test/index.js
+++ b/test/index.js
@@ -42,7 +42,10 @@ tests.add('`test-graphql-http` CLI without the URI argument.', async () => {
 
   await snapshot(
     JSON.stringify(
-      output.map(([type, value]) => [type, stripStackTraces(value)]),
+      {
+        stdout: stripStackTraces(output.stdout),
+        stderr: stripStackTraces(output.stderr)
+      },
       null,
       2
     ),
@@ -82,7 +85,10 @@ tests.add('`test-graphql-http` CLI with a noncompliant server.', async () => {
 
     await snapshot(
       JSON.stringify(
-        output.map(([type, value]) => [type, value.replace(uri, '<uri>')]),
+        {
+          stdout: output.stdout.replace(uri, '<uri>'),
+          stderr: output.stderr.replace(uri, '<uri>')
+        },
         null,
         2
       ),

--- a/test/recordChildProcess.js
+++ b/test/recordChildProcess.js
@@ -12,12 +12,21 @@ module.exports = function recordChildProcess(childProcess) {
   return new Promise((resolve, reject) => {
     const output = []
 
+    const add = (pipe, data) => {
+      const lastOutput = output[output.length - 1]
+      const text = data.toString()
+      if (lastOutput && lastOutput[0] === pipe)
+        // If the data came through the same pipe as the last data, concatenate
+        lastOutput[1] += text
+      else output.push([pipe, text])
+    }
+
     childProcess.stdout.on('data', data => {
-      output.push(['stdout', data.toString()])
+      add('stdout', data)
     })
 
     childProcess.stderr.on('data', data => {
-      output.push(['stderr', data.toString()])
+      add('stderr', data)
     })
 
     childProcess.once('error', reject)

--- a/test/recordChildProcess.js
+++ b/test/recordChildProcess.js
@@ -5,20 +5,19 @@
  * @kind function
  * @name recordChildProcess
  * @param {ChildProcess} childProcess Node.js child process.
- * @returns {Promise<{output: Array<Array<string, string>>, exitCode: number, signal: string}>} Resolves a multidimensional array of output types (`stderr` or `stdout`) and values, the exit code if the child exited on its own, or the signal by which the child process was terminated.
+ * @returns {Promise<{output: {stdout: string, stderr: string}, exitCode: number, signal: string}>} Resolves a multidimensional array of output types (`stderr` or `stdout`) and values, the exit code if the child exited on its own, or the signal by which the child process was terminated.
  * @ignore
  */
 module.exports = function recordChildProcess(childProcess) {
   return new Promise((resolve, reject) => {
-    const output = []
+    const output = {
+      stdout: '',
+      stderr: ''
+    }
 
     const add = (pipe, data) => {
-      const lastOutput = output[output.length - 1]
       const text = data.toString()
-      if (lastOutput && lastOutput[0] === pipe)
-        // If the data came through the same pipe as the last data, concatenate
-        lastOutput[1] += text
-      else output.push([pipe, text])
+      output[pipe] += text
     }
 
     childProcess.stdout.on('data', data => {

--- a/test/snapshots/cli-output-compliant.json
+++ b/test/snapshots/cli-output-compliant.json
@@ -1,14 +1,6 @@
 [
   [
     "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n"
-  ],
-  [
-    "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n"
-  ],
-  [
-    "stdout",
-    "\n\u001b[32m\u001b[1m2/2 tests passed.\u001b[39m\u001b[22m\n\n"
+    "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n\n\u001b[32m\u001b[1m2/2 tests passed.\u001b[39m\u001b[22m\n\n"
   ]
 ]

--- a/test/snapshots/cli-output-compliant.json
+++ b/test/snapshots/cli-output-compliant.json
@@ -1,6 +1,4 @@
-[
-  [
-    "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n\n\u001b[32m\u001b[1m2/2 tests passed.\u001b[39m\u001b[22m\n\n"
-  ]
-]
+{
+  "stdout": "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n\n\u001b[32m\u001b[1m2/2 tests passed.\u001b[39m\u001b[22m\n\n",
+  "stderr": ""
+}

--- a/test/snapshots/cli-output-noncompliant-node-v10.json
+++ b/test/snapshots/cli-output-noncompliant-node-v10.json
@@ -1,30 +1,4 @@
-[
-  [
-    "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31mInput A expected to strictly equal input B:\n  + expected - actual\n  \n  - 404\n  + 200\u001b[39m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31m\u001b[2mtests.add (lib/testGraphqlHttp.js:39:5)\u001b[39m\u001b[22m\n"
-  ],
-  [
-    "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31minvalid json response body at <uri>/ reason: Unexpected token N in JSON at position 0\u001b[39m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31m\u001b[2mnode_modules/node-fetch/lib/index.js:272:32\u001b[39m\u001b[22m\n"
-  ],
-  [
-    "stdout",
-    "\n\u001b[31m\u001b[1m0/2 tests passed.\u001b[39m\u001b[22m\n\n"
-  ]
-]
+{
+  "stdout": "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n\n\u001b[31m\u001b[1m0/2 tests passed.\u001b[39m\u001b[22m\n\n",
+  "stderr": "  \n  \u001b[31mInput A expected to strictly equal input B:\n  + expected - actual\n  \n  - 404\n  + 200\u001b[39m\n  \n  \u001b[31m\u001b[2mtests.add (lib/testGraphqlHttp.js:39:5)\u001b[39m\u001b[22m\n  \n  \u001b[31minvalid json response body at <uri>/ reason: Unexpected token N in JSON at position 0\u001b[39m\n  \n  \u001b[31m\u001b[2mnode_modules/node-fetch/lib/index.js:272:32\u001b[39m\u001b[22m\n"
+}

--- a/test/snapshots/cli-output-noncompliant-node-v12.json
+++ b/test/snapshots/cli-output-noncompliant-node-v12.json
@@ -1,22 +1,4 @@
-[
-  [
-    "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31mExpected values to be strictly equal:\n  \n  404 !== 200\u001b[39m\n  \n  \u001b[31m\u001b[2mlib/testGraphqlHttp.js:39:5\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
-  ],
-  [
-    "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31minvalid json response body at <uri>/ reason: Unexpected token N in JSON at position 0\u001b[39m\n  \n  \u001b[31m\u001b[2mnode_modules/node-fetch/lib/index.js:272:32\n  async lib/testGraphqlHttp.js:52:18\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
-  ],
-  [
-    "stdout",
-    "\n\u001b[31m\u001b[1m0/2 tests passed.\u001b[39m\u001b[22m\n\n"
-  ]
-]
+{
+  "stdout": "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n\n\u001b[31m\u001b[1m0/2 tests passed.\u001b[39m\u001b[22m\n\n",
+  "stderr": "  \n  \u001b[31mExpected values to be strictly equal:\n  \n  404 !== 200\u001b[39m\n  \n  \u001b[31m\u001b[2mlib/testGraphqlHttp.js:39:5\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n  \n  \u001b[31minvalid json response body at <uri>/ reason: Unexpected token N in JSON at position 0\u001b[39m\n  \n  \u001b[31m\u001b[2mnode_modules/node-fetch/lib/index.js:272:32\n  async lib/testGraphqlHttp.js:52:18\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
+}

--- a/test/snapshots/cli-output-noncompliant-node-v12.json
+++ b/test/snapshots/cli-output-noncompliant-node-v12.json
@@ -5,11 +5,7 @@
   ],
   [
     "stderr",
-    "  \n  \u001b[31mExpected values to be strictly equal:\n  \n  404 !== 200\u001b[39m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31m\u001b[2mlib/testGraphqlHttp.js:39:5\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
+    "  \n  \u001b[31mExpected values to be strictly equal:\n  \n  404 !== 200\u001b[39m\n  \n  \u001b[31m\u001b[2mlib/testGraphqlHttp.js:39:5\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
   ],
   [
     "stdout",
@@ -17,11 +13,7 @@
   ],
   [
     "stderr",
-    "  \n  \u001b[31minvalid json response body at <uri>/ reason: Unexpected token N in JSON at position 0\u001b[39m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31m\u001b[2mnode_modules/node-fetch/lib/index.js:272:32\n  async lib/testGraphqlHttp.js:52:18\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
+    "  \n  \u001b[31minvalid json response body at <uri>/ reason: Unexpected token N in JSON at position 0\u001b[39m\n  \n  \u001b[31m\u001b[2mnode_modules/node-fetch/lib/index.js:272:32\n  async lib/testGraphqlHttp.js:52:18\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
   ],
   [
     "stdout",

--- a/test/snapshots/cli-output-noncompliant-node-v13.json
+++ b/test/snapshots/cli-output-noncompliant-node-v13.json
@@ -1,30 +1,4 @@
-[
-  [
-    "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31mExpected values to be strictly equal:\n  \n  404 !== 200\u001b[39m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31m\u001b[2mlib/testGraphqlHttp.js:39:5\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
-  ],
-  [
-    "stdout",
-    "\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31minvalid json response body at <uri>/ reason: Unexpected token N in JSON at position 0\u001b[39m\n"
-  ],
-  [
-    "stderr",
-    "  \n  \u001b[31m\u001b[2mnode_modules/node-fetch/lib/index.js:272:32\n  async lib/testGraphqlHttp.js:52:18\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
-  ],
-  [
-    "stdout",
-    "\n\u001b[31m\u001b[1m0/2 tests passed.\u001b[39m\u001b[22m\n\n"
-  ]
-]
+{
+  "stdout": "\nTest: \u001b[1mQuery a field that resolves ok.\u001b[22m\n\nTest: \u001b[1mQuery a field that resolves an error.\u001b[22m\n\n\u001b[31m\u001b[1m0/2 tests passed.\u001b[39m\u001b[22m\n\n",
+  "stderr": "  \n  \u001b[31mExpected values to be strictly equal:\n  \n  404 !== 200\u001b[39m\n  \n  \u001b[31m\u001b[2mlib/testGraphqlHttp.js:39:5\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n  \n  \u001b[31minvalid json response body at <uri>/ reason: Unexpected token N in JSON at position 0\u001b[39m\n  \n  \u001b[31m\u001b[2mnode_modules/node-fetch/lib/index.js:272:32\n  async lib/testGraphqlHttp.js:52:18\n  async testGraphqlHttp (lib/testGraphqlHttp.js:69:3)\n  async testGraphqlHttpCLI (cli/test-graphql-http.js:21:5)\u001b[39m\u001b[22m\n"
+}

--- a/test/snapshots/cli-output-without-uri-arg.json
+++ b/test/snapshots/cli-output-without-uri-arg.json
@@ -1,10 +1,6 @@
 [
   [
     "stderr",
-    "test-graphql-https CLI error:\n"
-  ],
-  [
-    "stderr",
-    "  TypeError: Missing URI argument.\n"
+    "test-graphql-https CLI error:\n  TypeError: Missing URI argument.\n"
   ]
 ]

--- a/test/snapshots/cli-output-without-uri-arg.json
+++ b/test/snapshots/cli-output-without-uri-arg.json
@@ -1,6 +1,4 @@
-[
-  [
-    "stderr",
-    "test-graphql-https CLI error:\n  TypeError: Missing URI argument.\n"
-  ]
-]
+{
+  "stdout": "",
+  "stderr": "test-graphql-https CLI error:\n  TypeError: Missing URI argument.\n"
+}


### PR DESCRIPTION
Fixes #1 

I've wrestled this dragon before, and basically without very precise co-operation between the caller and the callee it's extremely hard to _guarantee_ the order (and amount) of data that will be sent through the pipes. They'll be broadly similar, but sometimes (as you're seeing on Mac intermittently) they'll come in with stderr and stdout in a different order, or with different "packet" sizes. Either you can choose to fight this by being very careful how you output things and doing low-level pipe manipulation on both sides, or you can accept it and just store stdout and stderr separately [like child_process.exec does in Node.js](https://nodejs.org/dist/latest-v13.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback). I went with the latter option because it requires the least maintenance and overhead.